### PR TITLE
feat: disabled handling to avoid class attributes that clash with `keywords` and `builtins`

### DIFF
--- a/.github/workflows/manual-release-candidate.yml
+++ b/.github/workflows/manual-release-candidate.yml
@@ -21,43 +21,63 @@ name: Manual Pre Release Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      release_candidate_suffix:
-        description: 'RC Suffix e.g. rc0, beta1, alpha2. Do not include a leading hyphen.'
-        required: true
-        type: string
+#    inputs:
+#      release_candidate_suffix:
+#        description: 'RC Suffix e.g. rc0, beta1, alpha2. Do not include a leading hyphen.'
+#        required: true
+#        type: string
 
 env:
   REPORTS_DIR: CI_reports
   DIST_DIR: dist
   DIST_ARTIFACT: python-dist
-  PYTHON_VERISON: "3.10"
-  POETRY_VERSION: "1.1.11"
+  PYTHON_SEMANTIC_RELEASE_VERSION: "7.33.2"
+  PYTHON_VERSION_DEFAULT: "3.10"
+  POETRY_VERSION: "1.1.12"
 
 jobs:
   release_candidate:
     runs-on: ubuntu-latest
     concurrency: release_candidate
     steps:
-      - name: Checkout code
+      - name: Checkout
+        # see https://github.com/actions/checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+
+      - name: Setup Python Environment
+        # see https://github.com/actions/setup-python
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERISON }}
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+          architecture: 'x64'
+
+      - name: Install and configure Poetry
+        # See https://github.com/marketplace/actions/install-poetry-action
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
       - name: Install dependencies
-        run: |
-          python -m pip install poetry=="$POETRY_VERSION" --upgrade pip
-          poetry config virtualenvs.create false
-          poetry install
-          python -m pip install python-semantic-release==7.33.2
-      - name: Apply Pre Release Version
-        run: |
-          RC_VERSION="$(semantic-release --noop --major print-version)-${{ github.event.inputs.release_candidate_suffix }}"
-          echo "RC Version will be: ${RC_VERSION}"
-          poetry version ${RC_VERSION}
-          poetry build
+        run: poetry install --no-root
+
+      - name: View poetry version
+        run: poetry --version
+
+      - name: Install semantic-release
+        run: pip install python-semantic-release==${{ env.PYTHON_SEMANTIC_RELEASE_VERSION }}
+
+      - name: Perform Release 📦
+        run: semantic-release publish --prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          REPOSITORY_USERNAME: __token__
+          REPOSITORY_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
       - name: Artifact python dist
         # see https://github.com/actions/upload-artifact
         uses: actions/upload-artifact@v3
@@ -65,8 +85,3 @@ jobs:
           name: ${{ env.DIST_ARTIFACT }}
           path: ${{ env.DIST_DIR }}/
           if-no-files-found: error
-      - name: Publish Pre Release 📦 to PyPI
-        # see https://github.com/pypa/gh-action-pypi-publish
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: poetry --version
 
       - name: Install semantic-release
-        run: pip install python-semantic-release=={{ env.PYTHON_SEMANTIC_RELEASE_VERSION }}
+        run: pip install python-semantic-release==${{ env.PYTHON_SEMANTIC_RELEASE_VERSION }}
 
       - name: Perform Release
         run: semantic-release publish

--- a/serializable/formatters.py
+++ b/serializable/formatters.py
@@ -17,10 +17,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) Paul Horton. All Rights Reserved.
 
-import builtins
 import re
 from abc import ABC, abstractmethod
-from keyword import iskeyword
 from typing import Type
 
 
@@ -43,16 +41,10 @@ class BaseNameFormatter(ABC):
 
     @classmethod
     def decode_handle_python_builtins_and_keywords(cls, name: str) -> str:
-        # if iskeyword(name) or getattr(builtins, name, False):
-        #     return f'{name}_'
         return name
 
     @classmethod
     def encode_handle_python_builtins_and_keywords(cls, name: str) -> str:
-        # if name.endswith('_'):
-        #     _name = name[:-1]
-        #     if iskeyword(_name) or getattr(builtins, _name, False):
-        #         return _name
         return name
 
 

--- a/serializable/formatters.py
+++ b/serializable/formatters.py
@@ -43,16 +43,16 @@ class BaseNameFormatter(ABC):
 
     @classmethod
     def decode_handle_python_builtins_and_keywords(cls, name: str) -> str:
-        if iskeyword(name) or getattr(builtins, name, False):
-            return f'{name}_'
+        # if iskeyword(name) or getattr(builtins, name, False):
+        #     return f'{name}_'
         return name
 
     @classmethod
     def encode_handle_python_builtins_and_keywords(cls, name: str) -> str:
-        if name.endswith('_'):
-            _name = name[:-1]
-            if iskeyword(_name) or getattr(builtins, _name, False):
-                return _name
+        # if name.endswith('_'):
+        #     _name = name[:-1]
+        #     if iskeyword(_name) or getattr(builtins, _name, False):
+        #         return _name
         return name
 
 

--- a/tests/model.py
+++ b/tests/model.py
@@ -203,9 +203,9 @@ class Book:
 
     def __init__(self, title: str, isbn: str, publish_date: date, authors: Iterable[str],
                  publisher: Optional[Publisher] = None, chapters: Optional[Iterable[Chapter]] = None,
-                 edition: Optional[BookEdition] = None, type_: BookType = BookType.FICTION,
-                 id_: Optional[UUID] = None, references: Optional[List[BookReference]] = None) -> None:
-        self._id_ = id_ or uuid4()
+                 edition: Optional[BookEdition] = None, type: BookType = BookType.FICTION,
+                 id: Optional[UUID] = None, references: Optional[List[BookReference]] = None) -> None:
+        self._id = id or uuid4()
         self._title = title
         self._isbn = isbn
         self._edition = edition
@@ -213,13 +213,13 @@ class Book:
         self._authors = set(authors)
         self._publisher = publisher
         self.chapters = list(chapters or [])
-        self._type_ = type_
+        self._type = type
         self.references = set(references or {})
 
     @property  # type: ignore[misc]
     @serializable.xml_sequence(1)
-    def id_(self) -> UUID:
-        return self._id_
+    def id(self) -> UUID:
+        return self._id
 
     @property  # type: ignore[misc]
     @serializable.xml_sequence(2)
@@ -267,8 +267,8 @@ class Book:
 
     @property  # type: ignore[misc]
     @serializable.xml_sequence(6)
-    def type_(self) -> BookType:
-        return self._type_
+    def type(self) -> BookType:
+        return self._type
 
     @property  # type: ignore[misc]
     @serializable.view(SchemaVersion4)
@@ -287,7 +287,7 @@ ThePhoenixProject_v1 = Book(
     authors=['Gene Kim', 'Kevin Behr', 'George Spafford'],
     publisher=Publisher(name='IT Revolution Press LLC'),
     edition=BookEdition(number=5, name='5th Anniversary Limited Edition'),
-    id_=UUID('f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
+    id=UUID('f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
 )
 
 ThePhoenixProject_v1.chapters.append(Chapter(number=1, title='Tuesday, September 2'))
@@ -300,7 +300,7 @@ ThePhoenixProject_v2 = Book(
     authors=['Gene Kim', 'Kevin Behr', 'George Spafford'],
     publisher=Publisher(name='IT Revolution Press LLC', address='10 Downing Street'),
     edition=BookEdition(number=5, name='5th Anniversary Limited Edition'),
-    id_=UUID('f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
+    id=UUID('f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
 )
 
 ThePhoenixProject_v2.chapters.append(Chapter(number=1, title='Tuesday, September 2'))

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -32,22 +32,22 @@ class TestFormatterCamelCase(TestCase):
         self.assertEqual('bookChapters', CamelCasePropertyNameFormatter.encode(property_name='book_chapters'))
 
     def test_encode_2(self) -> None:
-        self.assertEqual('id', CamelCasePropertyNameFormatter.encode(property_name='id_'))
+        self.assertEqual('id', CamelCasePropertyNameFormatter.encode(property_name='id'))
 
     def test_encode_3(self) -> None:
         self.assertEqual('book', CamelCasePropertyNameFormatter.encode(property_name='Book'))
 
     def test_encode_4(self) -> None:
-        self.assertEqual('type', CamelCasePropertyNameFormatter.encode(property_name='type_'))
+        self.assertEqual('type', CamelCasePropertyNameFormatter.encode(property_name='type'))
 
     def test_decode_1(self) -> None:
         self.assertEqual('book_chapters', CamelCasePropertyNameFormatter.decode(property_name='bookChapters'))
 
     def test_decode_2(self) -> None:
-        self.assertEqual('id_', CamelCasePropertyNameFormatter.decode(property_name='id'))
+        self.assertEqual('id', CamelCasePropertyNameFormatter.decode(property_name='id'))
 
     def test_decode_4(self) -> None:
-        self.assertEqual('type_', CamelCasePropertyNameFormatter.decode(property_name='type'))
+        self.assertEqual('type', CamelCasePropertyNameFormatter.decode(property_name='type'))
 
     def test_decode_class_name_1(self) -> None:
         self.assertEqual('Book', CamelCasePropertyNameFormatter.decode_as_class_name(name='book'))
@@ -62,7 +62,7 @@ class TestFormatterKebabCase(TestCase):
         self.assertEqual('book-chapters', KebabCasePropertyNameFormatter.encode(property_name='book_chapters'))
 
     def test_encode_2(self) -> None:
-        self.assertEqual('id', KebabCasePropertyNameFormatter.encode(property_name='id_'))
+        self.assertEqual('id', KebabCasePropertyNameFormatter.encode(property_name='id'))
 
     def test_encode_3(self) -> None:
         self.assertEqual('book', KebabCasePropertyNameFormatter.encode(property_name='Book'))
@@ -71,7 +71,7 @@ class TestFormatterKebabCase(TestCase):
         self.assertEqual('book_chapters', KebabCasePropertyNameFormatter.decode(property_name='book-chapters'))
 
     def test_decode_2(self) -> None:
-        self.assertEqual('id_', KebabCasePropertyNameFormatter.decode(property_name='id'))
+        self.assertEqual('id', KebabCasePropertyNameFormatter.decode(property_name='id'))
 
 
 class TestFormatterSnakeCase(TestCase):
@@ -80,7 +80,7 @@ class TestFormatterSnakeCase(TestCase):
         self.assertEqual('book_chapters', SnakeCasePropertyNameFormatter.encode(property_name='book_chapters'))
 
     def test_encode_2(self) -> None:
-        self.assertEqual('id', SnakeCasePropertyNameFormatter.encode(property_name='id_'))
+        self.assertEqual('id', SnakeCasePropertyNameFormatter.encode(property_name='id'))
 
     def test_encode_3(self) -> None:
         self.assertEqual('book', SnakeCasePropertyNameFormatter.encode(property_name='Book'))
@@ -89,4 +89,4 @@ class TestFormatterSnakeCase(TestCase):
         self.assertEqual('book_chapters', SnakeCasePropertyNameFormatter.decode(property_name='book_chapters'))
 
     def test_decode_2(self) -> None:
-        self.assertEqual('id_', SnakeCasePropertyNameFormatter.decode(property_name='id'))
+        self.assertEqual('id', SnakeCasePropertyNameFormatter.decode(property_name='id'))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -55,7 +55,7 @@ class TestJson(BaseTestCase):
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case.json')) as input_json:
             book: Book = Book.from_json(data=json.loads(input_json.read()))
-            self.assertEqual(str(ThePhoenixProject_v1.id_), 'f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
+            self.assertEqual(str(ThePhoenixProject_v1.id), 'f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
             self.assertEqual(ThePhoenixProject_v1.title, book.title)
             self.assertEqual(ThePhoenixProject_v1.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject_v1.edition, book.edition)
@@ -69,7 +69,7 @@ class TestJson(BaseTestCase):
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-references.json')) as input_json:
             book: Book = Book.from_json(data=json.loads(input_json.read()))
-            self.assertEqual(str(ThePhoenixProject.id_), 'f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
+            self.assertEqual(str(ThePhoenixProject.id), 'f3758bf0-0ff7-4366-a5e5-c209d4352b2d')
             self.assertEqual(ThePhoenixProject.title, book.title)
             self.assertEqual(ThePhoenixProject.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject.edition, book.edition)


### PR DESCRIPTION
After feedback from the community and early adopters, it was requested that logic that required data models to avoid attributes that clashed with Python's `keywords` and `builtins` was removed as:
1. The clashes would never be impactful for data model properties
2. The resulting data models look a little crappy :-) 

Example: https://github.com/CycloneDX/cyclonedx-python-lib/pull/290#discussion_r1122713863