### PR TITLE
fix: use `defusedxml` whenever we load XML to prevent XEE attacks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -46,6 +46,14 @@ python-versions = ">=3.7"
 toml = ["tomli"]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -135,8 +143,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-testing = ["importlib-resources (>=1.3)", "pytest-mypy", "pytest-black (>=0.3.7)", "flufl.flake8", "pyfakefs", "pep517", "packaging", "pytest-enabler (>=1.0.1)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=4.6)"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "isort"
@@ -189,9 +197,9 @@ typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-reports = ["lxml"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -236,8 +244,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -341,8 +349,8 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
 
 [package.extras]
-testing = ["pytest-timeout (>=1)", "pytest-randomly (>=1)", "pytest-mock (>=2)", "pytest-freezegun (>=0.4.1)", "pytest-env (>=0.6.2)", "pytest (>=4)", "packaging (>=20.0)", "flaky (>=3)", "coverage-enable-subprocess (>=1)", "coverage (>=4)"]
-docs = ["towncrier (>=21.3)", "sphinx-rtd-theme (>=0.4.3)", "sphinx-argparse (>=0.2.5)", "sphinx (>=3)", "proselint (>=0.10.2)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [[package]]
 name = "xmldiff"
@@ -373,7 +381,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8b9ca3d6f8a74531123ca41310494b62d9617c78e3581cfbbf18bc2305fc9cc4"
+content-hash = "18ea0b8b5f665d7fa927398f3d301817c20997ecb275253e04ec8c278db1a418"
 
 [metadata.files]
 attrs = [
@@ -439,6 +447,10 @@ coverage = [
     {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
     {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
+]
+defusedxml = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 distlib = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+defusedxml = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.6.0"

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -31,7 +31,7 @@ from io import StringIO, TextIOWrapper
 from json import JSONEncoder
 from sys import version_info
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union, cast
-from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, SubElement
 
 from defusedxml import ElementTree as SafeElementTree  # type: ignore
 
@@ -316,7 +316,7 @@ def _from_json(cls: Type[_T], data: Dict[str, Any]) -> object:
 
 
 def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, element_name: Optional[str] = None,
-            xmlns: Optional[str] = None) -> Union[ElementTree.Element, str]:
+            xmlns: Optional[str] = None) -> Union[Element, str]:
     logging.debug(f'Dumping {self} to XML with view {view_}...')
 
     this_e_attributes = {}
@@ -354,7 +354,7 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
     element_name = _namespace_element_name(tag_name=element_name,
                                            xmlns=xmlns) if element_name else _namespace_element_name(
         tag_name=CurrentFormatter.formatter.encode(self.__class__.__name__), xmlns=xmlns)
-    this_e = cast(ElementTree.Element, SafeElementTree.Element(element_name, this_e_attributes))
+    this_e = Element(element_name, this_e_attributes)
 
     # Handle remaining Properties that will be sub elements
     for k, prop_info in serializable_property_info.items():
@@ -377,7 +377,7 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
             new_key = prop_info.custom_names.get(SerializationType.XML, new_key)
 
             if v is None:
-                ElementTree.SubElement(this_e, _namespace_element_name(tag_name=new_key, xmlns=xmlns))
+                SubElement(this_e, _namespace_element_name(tag_name=new_key, xmlns=xmlns))
                 continue
 
             if new_key == '.':
@@ -392,28 +392,28 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
                 _array_type, nested_key = prop_info.xml_array_config
                 nested_key = _namespace_element_name(tag_name=nested_key, xmlns=xmlns)
                 if _array_type and _array_type == XmlArraySerializationType.NESTED:
-                    nested_e = ElementTree.SubElement(this_e, new_key)
+                    nested_e = SubElement(this_e, new_key)
                 else:
                     nested_e = this_e
                 for j in v:
                     if not prop_info.is_primitive_type() and not prop_info.is_enum:
                         nested_e.append(j.as_xml(view_=view_, as_string=False, element_name=nested_key, xmlns=xmlns))
                     elif prop_info.is_enum:
-                        ElementTree.SubElement(nested_e, nested_key).text = str(j.value)
+                        SubElement(nested_e, nested_key).text = str(j.value)
                     elif prop_info.concrete_type in (float, int):
-                        ElementTree.SubElement(nested_e, nested_key).text = str(j)
+                        SubElement(nested_e, nested_key).text = str(j)
                     elif prop_info.concrete_type is bool:
-                        ElementTree.SubElement(nested_e, nested_key).text = str(j).lower()
+                        SubElement(nested_e, nested_key).text = str(j).lower()
                     else:
                         # Assume type is str
-                        ElementTree.SubElement(nested_e, nested_key).text = str(j)
+                        SubElement(nested_e, nested_key).text = str(j)
             elif prop_info.custom_type:
                 if prop_info.is_helper_type():
-                    ElementTree.SubElement(this_e, new_key).text = str(prop_info.custom_type.serialize(v))
+                    SubElement(this_e, new_key).text = str(prop_info.custom_type.serialize(v))
                 else:
-                    ElementTree.SubElement(this_e, new_key).text = str(prop_info.custom_type(v))
+                    SubElement(this_e, new_key).text = str(prop_info.custom_type(v))
             elif prop_info.is_enum:
-                ElementTree.SubElement(this_e, new_key).text = str(v.value)
+                SubElement(this_e, new_key).text = str(v.value)
             elif not prop_info.is_primitive_type():
                 global_klass_name = f'{prop_info.concrete_type.__module__}.{prop_info.concrete_type.__name__}'
                 if global_klass_name in ObjectMetadataLibrary.klass_mappings:
@@ -422,24 +422,24 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
                 else:
                     # Handle properties that have a type that is not a Python Primitive (e.g. int, float, str)
                     if prop_info.string_format:
-                        ElementTree.SubElement(this_e, new_key).text = f'{v:{prop_info.string_format}}'
+                        SubElement(this_e, new_key).text = f'{v:{prop_info.string_format}}'
                     else:
-                        ElementTree.SubElement(this_e, new_key).text = str(v)
+                        SubElement(this_e, new_key).text = str(v)
             elif prop_info.concrete_type in (float, int):
-                ElementTree.SubElement(this_e, new_key).text = str(v)
+                SubElement(this_e, new_key).text = str(v)
             elif prop_info.concrete_type is bool:
-                ElementTree.SubElement(this_e, new_key).text = str(v).lower()
+                SubElement(this_e, new_key).text = str(v).lower()
             else:
                 # Assume type is str
-                ElementTree.SubElement(this_e, new_key).text = str(v)
+                SubElement(this_e, new_key).text = str(v)
 
     if as_string:
-        return cast(ElementTree.Element, SafeElementTree.tostring(this_e, 'unicode'))
+        return cast(Element, SafeElementTree.tostring(this_e, 'unicode'))
     else:
         return this_e
 
 
-def _from_xml(cls: Type[_T], data: Union[TextIOWrapper, ElementTree.Element],
+def _from_xml(cls: Type[_T], data: Union[TextIOWrapper, Element],
               default_namespace: Optional[str] = None) -> object:
     logging.debug(f'Rendering XML from {type(data)} to {cls}...')
     klass = ObjectMetadataLibrary.klass_mappings.get(f'{cls.__module__}.{cls.__qualname__}', None)
@@ -450,7 +450,7 @@ def _from_xml(cls: Type[_T], data: Union[TextIOWrapper, ElementTree.Element],
     klass_properties = ObjectMetadataLibrary.klass_property_mappings.get(f'{cls.__module__}.{cls.__qualname__}', {})
 
     if isinstance(data, TextIOWrapper):
-        data = cast(ElementTree.Element, SafeElementTree.fromstring(data.read()))
+        data = cast(Element, SafeElementTree.fromstring(data.read()))
 
     if default_namespace is None:
         _namespaces = dict([node for _, node in

--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -354,7 +354,7 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
     element_name = _namespace_element_name(tag_name=element_name,
                                            xmlns=xmlns) if element_name else _namespace_element_name(
         tag_name=CurrentFormatter.formatter.encode(self.__class__.__name__), xmlns=xmlns)
-    this_e = ElementTree.Element(element_name, this_e_attributes)
+    this_e = cast(ElementTree.Element, SafeElementTree.Element(element_name, this_e_attributes))
 
     # Handle remaining Properties that will be sub elements
     for k, prop_info in serializable_property_info.items():
@@ -434,7 +434,7 @@ def _as_xml(self: _T, view_: Optional[Type[_T]] = None, as_string: bool = True, 
                 ElementTree.SubElement(this_e, new_key).text = str(v)
 
     if as_string:
-        return ElementTree.tostring(this_e, 'unicode')
+        return cast(ElementTree.Element, SafeElementTree.tostring(this_e, 'unicode'))
     else:
         return this_e
 
@@ -454,7 +454,7 @@ def _from_xml(cls: Type[_T], data: Union[TextIOWrapper, ElementTree.Element],
 
     if default_namespace is None:
         _namespaces = dict([node for _, node in
-                            SafeElementTree.iterparse(StringIO(ElementTree.tostring(data, 'unicode')),
+                            SafeElementTree.iterparse(StringIO(SafeElementTree.tostring(data, 'unicode')),
                                                       events=['start-ns'])])
         if 'ns0' in _namespaces:
             default_namespace = _namespaces['ns0']

--- a/tests/base.py
+++ b/tests/base.py
@@ -19,11 +19,11 @@
 
 import json
 import os
-import xml
 from typing import Any
 from unittest import TestCase
 
 import lxml  # type: ignore
+from defusedxml import ElementTree as SafeElementTree  # type: ignore
 from xmldiff import main  # type: ignore
 from xmldiff.actions import MoveNode  # type: ignore
 
@@ -48,12 +48,12 @@ class BaseTestCase(TestCase):
         )
 
     def assertEqualXml(self, a: str, b: str) -> None:
-        a = xml.etree.ElementTree.tostring(
-            xml.etree.ElementTree.fromstring(a, lxml.etree.XMLParser(remove_blank_text=True, remove_comments=True)),
+        a = SafeElementTree.tostring(
+            SafeElementTree.fromstring(a, lxml.etree.XMLParser(remove_blank_text=True, remove_comments=True)),
             'unicode'
         )
-        b = xml.etree.ElementTree.tostring(
-            xml.etree.ElementTree.fromstring(b, lxml.etree.XMLParser(remove_blank_text=True, remove_comments=True)),
+        b = SafeElementTree.tostring(
+            SafeElementTree.fromstring(b, lxml.etree.XMLParser(remove_blank_text=True, remove_comments=True)),
             'unicode'
         )
         diff_results = main.diff_texts(a, b, diff_options={'F': 0.5})

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -19,7 +19,8 @@
 
 import logging
 import os
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree as SafeElementTree
 
 from serializable.formatters import (
     CamelCasePropertyNameFormatter,
@@ -75,7 +76,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_cc1(self) -> None:
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-1-v1.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject_v1.title, book.title)
             self.assertEqual(ThePhoenixProject_v1.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject_v1.edition, book.edition)
@@ -87,7 +88,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_cc1_v2(self) -> None:
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-1-v2.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject.title, book.title)
             self.assertEqual(ThePhoenixProject.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject.edition, book.edition)
@@ -101,7 +102,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_cc1_v3(self) -> None:
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-1-v3.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject_v1.title, book.title)
             self.assertEqual(ThePhoenixProject_v1.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject_v1.edition, book.edition)
@@ -115,7 +116,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_cc1_v4(self) -> None:
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-1-v4.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject.title, book.title)
             self.assertEqual(ThePhoenixProject.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject.edition, book.edition)
@@ -129,7 +130,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_cc1_with_ignored(self) -> None:
         CurrentFormatter.formatter = CamelCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-camel-case-with-ignored.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject_v1.title, book.title)
             self.assertEqual(ThePhoenixProject_v1.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject_v1.edition, book.edition)
@@ -153,7 +154,7 @@ class TestXml(BaseTestCase):
     def test_deserialize_tfp_sc1(self) -> None:
         CurrentFormatter.formatter = SnakeCasePropertyNameFormatter
         with open(os.path.join(FIXTURES_DIRECTORY, 'the-phoenix-project-snake-case-1.xml')) as input_xml:
-            book: Book = Book.from_xml(data=ElementTree.fromstring(input_xml.read()))
+            book: Book = Book.from_xml(data=SafeElementTree.fromstring(input_xml.read()))
             self.assertEqual(ThePhoenixProject_v1.title, book.title)
             self.assertEqual(ThePhoenixProject_v1.isbn, book.isbn)
             self.assertEqual(ThePhoenixProject_v1.edition, book.edition)


### PR DESCRIPTION
As per feedback on https://github.com/CycloneDX/cyclonedx-python-lib/pull/341#discussion_r1124647186