### PR TITLE
Keep `LICENSE` in `.dist-info` when building wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/madpah/serializable"
 packages = [
     { include = "serializable" }
 ]
-include = [
-    "LICENSE"
-]
 classifiers = [
     # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier
     # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Poetry automatically detects and includes `LICENSE` files in `….dist-info/` when it builds a wheel.

If `LICENSE` is also declared as a pattern in Poetry’s `include` list in `pyproject.toml`, then the file will appear in the root directory of the wheel, too:

```plain
Path = /var/lib/aurbuild/x86_64/claudia/build/python-py-serializable/src/serializable-0.12.0/dist/py_serializable-0.12.0-py3-none-any.whl
Type = zip
Physical Size = 22557

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
1980-01-01 00:00:00 .....        11357         3948  LICENSE
1980-01-01 00:00:00 .....        52795         9275  serializable/__init__.py
1980-01-01 00:00:00 .....         3382          923  serializable/formatters.py
1980-01-01 00:00:00 .....         3690         1180  serializable/helpers.py
1980-01-01 00:00:00 .....          153          117  serializable/py.typed
1980-01-01 00:00:00 .....        11357         3948  py_serializable-0.12.0.dist-info/LICENSE
1980-01-01 00:00:00 .....         3845         1449  py_serializable-0.12.0.dist-info/METADATA
1980-01-01 00:00:00 .....           88           85  py_serializable-0.12.0.dist-info/WHEEL
2016-01-01 00:00:00 .....          718          408  py_serializable-0.12.0.dist-info/RECORD
------------------- ----- ------------ ------------  ------------------------
2016-01-01 00:00:00              87385        21333  9 files
```

Note how the wheel contains two identical copies of your `LICENSE` file:  
one copy in the `….dist-info/` directory, picked up automatically by Poetry, and a second copy in the root directory of the wheel.

Including a generically-named file directly in a wheel’s root directory may cause problems:

1. The `LICENSE` file is going to turn up at the top level of `site-packages` directly. That’s misleading, because anyone who’d browse `site-packages` might conclude that the license be valid for all packages, not just `serializable`, which is incorrect.

2. Having generic files at the top level of `site-packages` causes conflicts with other wheels that happen to include the same file. For example, I’ve had `LICENSE` files coming from two different wheels, excluding `serializable`, sitting at the top level of my `site-packages` directory so I could install only one of them.

I propose to remove the `LICENSE` pattern from the `include` list.  
Poetry automatically picks up files named `LICENSE`, and drops them either into an sdist’s root directory (when building an sdist)  or into `py_serializable-[version].dist-info/` (when building a wheel).
