### PR TITLE
chore: test with python 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         include:
           - # test with the locked dependencies
-            python-version: '3.11'
+            python-version: '3.12'
             toxenv-factor: 'locked'
 
           - # test with the lowest dependencies
@@ -119,7 +119,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
-          - "3.11"  # highest supported
+          - "3.12"  # highest supported
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,9 +57,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
           architecture: 'x64'
 
-      - name: Upgrade Virtualenv
-        run: virtualenv --upgrade-embed-wheels
-
       - name: Install poetry
         # see https://github.com/marketplace/actions/setup-poetry
         uses: Gr1N/setup-poetry@v8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -159,7 +159,7 @@ jobs:
         run: poetry build
 
       - name: Run tox
-        run: poetry run tox -v -e py-${{ matrix.toxenv-factor }} -s false
+        run: poetry run tox -v -r -e py-${{ matrix.toxenv-factor }} -s false
 
       - name: Generate coverage reports
         run: >

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,6 +57,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
           architecture: 'x64'
 
+      - name: Upgrade Virtualenv
+        run: virtualenv --upgrade-embed-wheels
+
       - name: Install poetry
         # see https://github.com/marketplace/actions/setup-poetry
         uses: Gr1N/setup-poetry@v8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Typing :: Typed'
 ]
 keywords = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # This file is part of py-serializable
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +39,7 @@ commands_pre =
     poetry run pip freeze
 commands =
     poetry run coverage run --source=serializable -m unittest -v
-download = True
+usedevelop = False
 
 [testenv:mypy{,-locked,-lowest}]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ envlist =
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False
+download = False
 
 [testenv]
 # settings in this category apply to all other testenv, if not overwritten

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,6 @@ envlist =
     py{312,311,310,39,38,37}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
-usedevelop = False
-download = False
 
 [testenv]
 # settings in this category apply to all other testenv, if not overwritten
@@ -43,6 +41,7 @@ commands_pre =
     poetry run pip freeze
 commands =
     poetry run coverage run --source=serializable -m unittest -v
+download = True
 
 [testenv:mypy{,-locked,-lowest}]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ envlist =
     py{312,311,310,39,38,37}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
+usedevelop = False
 
 [testenv]
 # settings in this category apply to all other testenv, if not overwritten
@@ -39,7 +40,6 @@ commands_pre =
     poetry run pip freeze
 commands =
     poetry run coverage run --source=serializable -m unittest -v
-usedevelop = False
 
 [testenv:mypy{,-locked,-lowest}]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ minversion = 3.10
 envlist =
     flake8
     mypy-{locked,lowest}
-    py{311,310,39,38,37}-{locked,lowest}
+    py{312,311,310,39,38,37}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False


### PR DESCRIPTION
appears to be bug-free now.

~~currently fails because of an issue with virtualenv and outdated setuptools/pip ....~~
```
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```
https://github.com/madpah/serializable/actions/runs/6423355054/job/17441702474#step:8:48
see https://pythontest.com/posts/2023/2023-10-02-py312-impimporter/ 