### PR TITLE
fix: log placeholder

### DIFF
--- a/serializable/__init__.py
+++ b/serializable/__init__.py
@@ -355,7 +355,7 @@ class _JsonSerializable(Protocol):
                     f'There was an AttributeError deserializing JSON to {cls} the Property {prop_info}: {e}'
                 ) from e
 
-        _logger.debug('Creating $s from %s', cls, _data)
+        _logger.debug('Creating %s from %s', cls, _data)
 
         return cls(**_data)
 


### PR DESCRIPTION
Thanks for `serializable`, and congratulations on `0.17.0`!

[Downstream](https://github.com/conda-forge/py-serializable-feedstock/pull/7), we noted some new test failures when run with debug [logging](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=854219&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=2500). 

```
TypeError: not all arguments converted during string formatting
```

We'll probably ship `0.17.0` with this patch, but wanted to hoist it here for visibility.

Thanks again!