### PR TITLE
fix: serialization of `datetime` without timezone with local time offset

### DIFF
--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -179,9 +179,9 @@ class XsdDateTime(BaseHelper):
     @staticmethod
     def __fix_tz(dt: datetime) -> datetime:
         """
-        Fix a violation of ISO8601: python omits the timezone if in doublt, but the ISO assumes local TZ
-        > If no UTC relation information is given with a time representation,
-        > the time is assumed to be in local time.
+        Fix for Python's  violation of ISO8601: `datetime.isoformat()` might omit the time offset when in doubt,
+        but the ISO-8601 assumes local time zone.
+        Anyway, the time offset is mandatory.
         """
         return dt.astimezone() \
             if dt.tzinfo is None \

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -179,7 +179,7 @@ class XsdDateTime(BaseHelper):
     @staticmethod
     def __fix_tz(dt: datetime) -> datetime:
         """
-        Fix for Python's  violation of ISO8601: `datetime.isoformat()` might omit the time offset when in doubt,
+        Fix for Python's violation of ISO8601: `datetime.isoformat()` might omit the time offset when in doubt,
         but the ISO-8601 assumes local time zone.
         Anyway, the time offset is mandatory.
         """

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -179,9 +179,9 @@ class XsdDateTime(BaseHelper):
     @staticmethod
     def __fix_tz(dt: datetime) -> datetime:
         """
-        Fix for Python's violation of ISO8601: `datetime.isoformat()` might omit the time offset when in doubt,
+        Fix for Python's violation of ISO8601: :py:meth:`datetime.isoformat()` might omit the time offset when in doubt,
         but the ISO-8601 assumes local time zone.
-        Anyway, the time offset is mandatory.
+        Anyway, the time offset is mandatory for this purpose.
         """
         return dt.astimezone() \
             if dt.tzinfo is None \

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -176,10 +176,23 @@ class XsdDate(BaseHelper):
 
 class XsdDateTime(BaseHelper):
 
+    @staticmethod
+    def __fix_tz(dt: datetime):
+        """
+        Fix a violation of ISO8601: python omits the timezone if in doublt, but the ISO assumes local TZ
+        > If no UTC relation information is given with a time representation,
+        > the time is assumed to be in local time.
+        """
+        if dt.tzinfo is None:
+            # ! Do not work with a constant value for `tzinfo`, even though the TZ will not shift,
+            # but the daylight-saving-time offset might change during longer runtimes
+            return dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
+        return dt
+
     @classmethod
     def serialize(cls, o: Any) -> str:
         if isinstance(o, datetime):
-            return o.isoformat()
+            return cls.__fix_tz(o).isoformat()
 
         raise ValueError(f'Attempt to serialize a non-date: {o.__class__}')
 

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -183,11 +183,9 @@ class XsdDateTime(BaseHelper):
         > If no UTC relation information is given with a time representation,
         > the time is assumed to be in local time.
         """
-        if dt.tzinfo is None:
-            # ! Do not work with a constant value for `tzinfo`, even though the TZ will not shift,
-            # but the daylight-saving-time offset might change during longer runtimes
-            return dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
-        return dt
+        return dt.astimezone() \
+            if dt.tzinfo is None \
+            else dt
 
     @classmethod
     def serialize(cls, o: Any) -> str:

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -177,7 +177,7 @@ class XsdDate(BaseHelper):
 class XsdDateTime(BaseHelper):
 
     @staticmethod
-    def __fix_tz(dt: datetime):
+    def __fix_tz(dt: datetime) -> datetime:
         """
         Fix a violation of ISO8601: python omits the timezone if in doublt, but the ISO assumes local TZ
         > If no UTC relation information is given with a time representation,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -151,11 +151,11 @@ class TestXsdDateTime(TestCase):
         )
 
     def test_serialize_1(self) -> None:
-        self.assertEqual(
+        self.assertRegex(
             XsdDateTime.serialize(
                 o=datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
             ),
-            '2001-10-26T21:32:52.012679'
+            r'2001-10-26T21:32:52.012679(?:Z|[+-]\d\d:\d\d)'
         )
 
     def test_serialize_2(self) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -28,25 +28,25 @@ class TestIso8601Date(TestCase):
 
     def test_serialize_date(self) -> None:
         self.assertEqual(
-            Iso8601Date.serialize(o=date(year=2022, month=8, day=3)),
+            Iso8601Date.serialize(date(year=2022, month=8, day=3)),
             '2022-08-03'
         )
 
     def test_serialize_datetime(self) -> None:
         self.assertEqual(
-            Iso8601Date.serialize(o=datetime(year=2022, month=8, day=3)),
+            Iso8601Date.serialize(datetime(year=2022, month=8, day=3)),
             '2022-08-03'
         )
 
     def test_deserialize_valid_date(self) -> None:
         self.assertEqual(
-            Iso8601Date.deserialize(o='2022-08-03'),
+            Iso8601Date.deserialize('2022-08-03'),
             date(year=2022, month=8, day=3)
         )
 
     def test_deserialize_valid(self) -> None:
         with self.assertRaises(ValueError):
-            Iso8601Date.deserialize(o='2022-08-03zzz')
+            Iso8601Date.deserialize('2022-08-03zzz')
 
 
 class TestXsdDate(TestCase):
@@ -56,14 +56,14 @@ class TestXsdDate(TestCase):
 
     def test_deserialize_valid_1(self) -> None:
         self.assertEqual(
-            XsdDate.deserialize(o='2001-10-26'),
+            XsdDate.deserialize('2001-10-26'),
             date(year=2001, month=10, day=26)
         )
 
     def test_deserialize_valid_2(self) -> None:
         with self.assertLogs(logger) as logs:
             self.assertEqual(
-                XsdDate.deserialize(o='2001-10-26+02:00'),
+                XsdDate.deserialize('2001-10-26+02:00'),
                 date(year=2001, month=10, day=26)
             )
         self.assertIn(
@@ -74,7 +74,7 @@ class TestXsdDate(TestCase):
     def test_deserialize_valid_3(self) -> None:
         with self.assertLogs(logger) as logs:
             self.assertEqual(
-                XsdDate.deserialize(o='2001-10-26Z'),
+                XsdDate.deserialize('2001-10-26Z'),
                 date(year=2001, month=10, day=26)
             )
         self.assertIn(
@@ -85,7 +85,7 @@ class TestXsdDate(TestCase):
     def test_deserialize_valid_4(self) -> None:
         with self.assertLogs(logger) as logs:
             self.assertEqual(
-                XsdDate.deserialize(o='2001-10-26+00:00'),
+                XsdDate.deserialize('2001-10-26+00:00'),
                 date(year=2001, month=10, day=26)
             )
         self.assertIn(
@@ -95,13 +95,13 @@ class TestXsdDate(TestCase):
 
     def test_deserialize_valid_5(self) -> None:
         self.assertEqual(
-            XsdDate.deserialize(o='-2001-10-26'),
+            XsdDate.deserialize('-2001-10-26'),
             date(year=2001, month=10, day=26)
         )
 
     def test_serialize_1(self) -> None:
         self.assertEqual(
-            XsdDate.serialize(o=date(year=2001, month=10, day=26)),
+            XsdDate.serialize(date(year=2001, month=10, day=26)),
             '2001-10-26'
         )
 
@@ -113,13 +113,13 @@ class TestXsdDateTime(TestCase):
 
     def test_deserialize_valid_1(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='2001-10-26T21:32:52'),
+            XsdDateTime.deserialize('2001-10-26T21:32:52'),
             datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, tzinfo=None)
         )
 
     def test_deserialize_valid_2(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='2001-10-26T21:32:52+02:00'),
+            XsdDateTime.deserialize('2001-10-26T21:32:52+02:00'),
             datetime(
                 year=2001, month=10, day=26, hour=21, minute=32, second=52,
                 tzinfo=timezone(timedelta(seconds=7200))
@@ -128,42 +128,46 @@ class TestXsdDateTime(TestCase):
 
     def test_deserialize_valid_3(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='2001-10-26T19:32:52Z'),
+            XsdDateTime.deserialize('2001-10-26T19:32:52Z'),
             datetime(year=2001, month=10, day=26, hour=19, minute=32, second=52, tzinfo=timezone.utc)
         )
 
     def test_deserialize_valid_4(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='2001-10-26T19:32:52+00:00'),
+            XsdDateTime.deserialize('2001-10-26T19:32:52+00:00'),
             datetime(year=2001, month=10, day=26, hour=19, minute=32, second=52, tzinfo=timezone.utc)
         )
 
     def test_deserialize_valid_5(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='-2001-10-26T21:32:52'),
+            XsdDateTime.deserialize('-2001-10-26T21:32:52'),
             datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, tzinfo=None)
         )
 
     def test_deserialize_valid_6(self) -> None:
         self.assertEqual(
-            XsdDateTime.deserialize(o='2001-10-26T21:32:52.12679'),
+            XsdDateTime.deserialize('2001-10-26T21:32:52.12679'),
             datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
         )
 
     def test_serialize_1(self) -> None:
-        self.assertRegex(
-            XsdDateTime.serialize(
-                o=datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
-            ),
-            r'2001-10-26T21:32:52.012679(?:Z|[+-]\d\d:\d\d)'
+        serialized = XsdDateTime.serialize(
+            # assume winter time
+            datetime(year=2001, month=2, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
         )
+        self.assertRegex(serialized, r'2001-02-26T21:32:52.012679(?:Z|[+-]\d\d:\d\d)')
 
     def test_serialize_2(self) -> None:
-        self.assertEqual(
-            XsdDateTime.serialize(
-                o=datetime(
-                    year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=timezone.utc
-                )
-            ),
-            '2001-10-26T21:32:52.012679+00:00'
+        serialized = XsdDateTime.serialize(
+            # assume summer time
+            datetime(year=2001, month=7, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
         )
+        self.assertRegex(serialized, r'2001-07-26T21:32:52.012679(?:Z|[+-]\d\d:\d\d)')
+
+    def test_serialize_3(self) -> None:
+        serialized = XsdDateTime.serialize(
+            datetime(
+                year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=timezone.utc
+            )
+        )
+        self.assertEqual(serialized, '2001-10-26T21:32:52.012679+00:00')


### PR DESCRIPTION
serializing a datetime that had no timezone caused invalid results.
this is fixed.

fixes https://github.com/madpah/serializable/issues/74