### PR TITLE
fix: date/time deserialization with fractional seconds

### DIFF
--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -205,7 +205,7 @@ class XsdDateTime(BaseHelper):
 
             # Ensure either 0 or exactly 6 decimal places for seconds
             # Background: py<3.11 supports either 6 or 0 digits for milliseconds
-            v = re_sub(r'(\.\d{1,6})\d*', lambda m: f'{(float(m.group(0))):.6f}'[1:], v)
+            v = re_sub(r'\.\d+', lambda m: f'{(float(m.group(0))):.6f}'[1:], v)
 
             if v.endswith('Z'):
                 # Replace ZULU time with 00:00 offset

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -198,8 +198,9 @@ class XsdDateTime(BaseHelper):
 
     if sys.version_info < (3, 11):
         # Ensure either 0 or exactly 6 decimal places for seconds
-        #Background: py<3.11 supports either 6 or 0 digits for milliseconds
+        # Background: py<3.11 supports either 6 or 0 digits for milliseconds
         __PATTERN_FRACTION = re_compile(r'\.\d+')
+
         @classmethod
         def __py311compat_seconds_fraction(cls, v: str) -> str:
             return cls.__PATTERN_FRACTION.sub(lambda m: f'{(float(m.group(0))):.6f}'[1:], v)
@@ -207,7 +208,7 @@ class XsdDateTime(BaseHelper):
         @staticmethod
         def __py311compat_seconds_fraction(v: str) -> str:
             return v
-    
+
     @classmethod
     def deserialize(cls, o: Any) -> datetime:
         try:

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -203,9 +203,9 @@ class XsdDateTime(BaseHelper):
                 # Remove any leading hyphen
                 v = v[1:]
 
-            # Ensure any milliseconds are 6 digits
-            # Background: py<3.11 supports six or less digits for milliseconds
-            v = re_sub(r'\.(\d{1,})', lambda m: f'.{int(m.group()[1:]):06}'[0:7], v)
+            # Ensure either 0 or exactly 6 decimal places for seconds
+            # Background: py<3.11 supports either 6 or 0 digits for milliseconds
+            v = re_sub(r'(\.\d{1,6})\d*', lambda m: f'{(float(m.group(0))):.6f}'[1:], v)
 
             if v.endswith('Z'):
                 # Replace ZULU time with 00:00 offset

--- a/serializable/helpers.py
+++ b/serializable/helpers.py
@@ -202,7 +202,7 @@ class XsdDateTime(BaseHelper):
                 o = str(o)[1:]
 
             # Ensure any milliseconds are 6 digits
-            o = re_sub(r'\.(\d{1,6})', lambda v: f'.{int(v.group()[1:]):06}', str(o))
+            o = re_sub(r'\.(\d{1,})', lambda v: f'.{int(v.group()[1:]):06}'[0:7], str(o))
 
             if str(o).endswith('Z'):
                 # Replace ZULU time with 00:00 offset

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -162,6 +162,7 @@ class TestXsdDateTime(TestCase):
     def test_deserialize_valid_8(self) -> None:
         """Test that more than 6 decimal places in the seconds field is parsed correctly."""
         self.assertEqual(
+            # values are chosen to showcase rounding on microseconds
             XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
             datetime(year=2024, month=9, day=23, hour=8, minute=6,
                      second=9, microsecond=185597, tzinfo=timezone.utc)
@@ -170,6 +171,7 @@ class TestXsdDateTime(TestCase):
     def test_deserialize_valid_9(self) -> None:
         """Test that a lot more than 6 decimal places in the seconds is parsed correctly."""
         self.assertEqual(
+            # values are chosen to showcase rounding on microseconds
             XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666'),
             datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185597, tzinfo=None)
         )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -150,6 +150,24 @@ class TestXsdDateTime(TestCase):
             datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
         )
 
+    def test_deserialize_valid_7(self) -> None:
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.185596Z'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)
+        )
+
+    def test_deserialize_valid_8(self) -> None:
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)
+        )
+
+    def test_deserialize_valid_9(self) -> None:
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666Z'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)
+        )
+
     def test_serialize_1(self) -> None:
         serialized = XsdDateTime.serialize(
             # assume winter time

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -151,18 +151,21 @@ class TestXsdDateTime(TestCase):
         )
 
     def test_deserialize_valid_7(self) -> None:
+        """Test that exactly 6 decimal places in the seconds field is parsed correctly."""
         self.assertEqual(
             XsdDateTime.deserialize('2024-09-23T08:06:09.185596Z'),
             datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)
         )
 
     def test_deserialize_valid_8(self) -> None:
+        """Test that more than 6 decimal places in the seconds field is truncated and parsed correctly."""
         self.assertEqual(
             XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
             datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)
         )
 
     def test_deserialize_valid_9(self) -> None:
+        """Test that a lot more than 6 decimal places in the seconds field is truncated and parsed correctly."""
         self.assertEqual(
             XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666Z'),
             datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=timezone.utc)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -153,11 +153,11 @@ class TestXsdDateTime(TestCase):
             # Make sure the parsed datetime is what we expect
             self.assertEqual(
                 XsdDateTime.deserialize('2001-10-26T21:32:52.12679'),
-                datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=12679, tzinfo=None)
+                datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=126790, tzinfo=None)
             )
 
             # Make sure the string provided to fromisoformat was correctly padded (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2001-10-26T21:32:52.012679')
+            datetime_mock.fromisoformat.assert_called_with('2001-10-26T21:32:52.126790')
 
     def test_deserialize_valid_7(self) -> None:
         """Test that exactly 6 decimal places in the seconds field is not altered and parsed correctly."""
@@ -185,11 +185,11 @@ class TestXsdDateTime(TestCase):
             self.assertEqual(
                 XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
                 datetime(year=2024, month=9, day=23, hour=8, minute=6,
-                         second=9, microsecond=185596, tzinfo=timezone.utc)
+                         second=9, microsecond=185597, tzinfo=timezone.utc)
             )
 
             # Make sure the string provided to fromisoformat was truncated (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185596+00:00')
+            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185597+00:00')
 
     def test_deserialize_valid_9(self) -> None:
         """Test that a lot more than 6 decimal places in the seconds field is truncated and parsed correctly."""
@@ -199,11 +199,11 @@ class TestXsdDateTime(TestCase):
 
             self.assertEqual(
                 XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666'),
-                datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185596, tzinfo=None)
+                datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185597, tzinfo=None)
             )
 
             # Make sure the string provided to fromisoformat was truncated (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185596')
+            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185597')
 
     def test_serialize_1(self) -> None:
         serialized = XsdDateTime.serialize(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@
 # Copyright (c) Paul Horton. All Rights Reserved.
 
 from datetime import date, datetime, timedelta, timezone
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from serializable import logger
 from serializable.helpers import Iso8601Date, XsdDate, XsdDateTime
@@ -145,65 +145,34 @@ class TestXsdDateTime(TestCase):
         )
 
     def test_deserialize_valid_6(self) -> None:
-        """Test that less than 6 decimal places in the seconds field is padded to 6 and parsed correctly."""
-
-        # Use mock wrapping datetime so we can check that it was given a correctly padded string
-        with mock.patch('serializable.helpers.datetime', wraps=datetime) as datetime_mock:
-
-            # Make sure the parsed datetime is what we expect
-            self.assertEqual(
-                XsdDateTime.deserialize('2001-10-26T21:32:52.12679'),
-                datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=126790, tzinfo=None)
-            )
-
-            # Make sure the string provided to fromisoformat was correctly padded (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2001-10-26T21:32:52.126790')
+        """Test that less than 6 decimal places in the seconds field is parsed correctly."""
+        self.assertEqual(
+            XsdDateTime.deserialize('2001-10-26T21:32:52.12679'),
+            datetime(year=2001, month=10, day=26, hour=21, minute=32, second=52, microsecond=126790, tzinfo=None)
+        )
 
     def test_deserialize_valid_7(self) -> None:
-        """Test that exactly 6 decimal places in the seconds field is not altered and parsed correctly."""
-
-        # Use mock wrapping datetime so we can check that the string was not altered
-        with mock.patch('serializable.helpers.datetime', wraps=datetime) as datetime_mock:
-
-            # Make sure the parsed datetime is what we expect
-            self.assertEqual(
-                XsdDateTime.deserialize('2024-09-23T08:06:09.185596Z'),
-                datetime(year=2024, month=9, day=23, hour=8, minute=6,
-                         second=9, microsecond=185596, tzinfo=timezone.utc)
-            )
-
-            # Make sure the string provided to fromisoformat was not altered (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185596+00:00')
+        """Test that exactly 6 decimal places in the seconds field is parsed correctly."""
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.185596Z'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6,
+                     second=9, microsecond=185596, tzinfo=timezone.utc)
+        )
 
     def test_deserialize_valid_8(self) -> None:
-        """Test that more than 6 decimal places in the seconds field is truncated and parsed correctly."""
-
-        # Use mock wrapping datetime so we can check that the string was truncated
-        with mock.patch('serializable.helpers.datetime', wraps=datetime) as datetime_mock:
-
-            # Make sure the parsed datetime is what we expect
-            self.assertEqual(
-                XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
-                datetime(year=2024, month=9, day=23, hour=8, minute=6,
-                         second=9, microsecond=185597, tzinfo=timezone.utc)
-            )
-
-            # Make sure the string provided to fromisoformat was truncated (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185597+00:00')
+        """Test that more than 6 decimal places in the seconds field is parsed correctly."""
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.185596536Z'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6,
+                     second=9, microsecond=185597, tzinfo=timezone.utc)
+        )
 
     def test_deserialize_valid_9(self) -> None:
-        """Test that a lot more than 6 decimal places in the seconds field is truncated and parsed correctly."""
-
-        # Use mock wrapping datetime so we can check that the string was truncated
-        with mock.patch('serializable.helpers.datetime', wraps=datetime) as datetime_mock:
-
-            self.assertEqual(
-                XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666'),
-                datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185597, tzinfo=None)
-            )
-
-            # Make sure the string provided to fromisoformat was truncated (pre 3.11 it needs 0 or 6 decimals)
-            datetime_mock.fromisoformat.assert_called_with('2024-09-23T08:06:09.185597')
+        """Test that a lot more than 6 decimal places in the seconds is parsed correctly."""
+        self.assertEqual(
+            XsdDateTime.deserialize('2024-09-23T08:06:09.18559653666666666666666666666666'),
+            datetime(year=2024, month=9, day=23, hour=8, minute=6, second=9, microsecond=185597, tzinfo=None)
+        )
 
     def test_serialize_1(self) -> None:
         serialized = XsdDateTime.serialize(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@
 # Copyright (c) Paul Horton. All Rights Reserved.
 
 from datetime import date, datetime, timedelta, timezone
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from serializable import logger
 from serializable.helpers import Iso8601Date, XsdDate, XsdDateTime


### PR DESCRIPTION
Hi,

Currently on Python 3.10 and earlier there is an exception thrown if you try to parse a JSON file with more than 6 fractional seconds (the decimals) in a JSON file. ISO8601 datetimes are allowed to have [any](https://en.wikipedia.org/wiki/ISO_8601#Times) number of fractional seconds but the regex fix applied by this library to allow Python to parse ISO8601 timestamps that is needed pre Python 3.11 due to weirdness around Pythons ISO parsing requiring either 0 or 6 fractional seconds currently only pads the fractional seconds if required and does not truncate if the timestamp is too long which was causing me issues parsing a JSON SBOM file generated by cargo-cyclonedx which includes 9 decimal places on its timestamp for some reason. This is only an issue pre Python 3.11 since in 3.11 they made `datetime.fromisoformat` ISO compliant.

I have added some tests which showcase the issue and applied a fix to the padding code of datetime deserialization.